### PR TITLE
WIP: Add Codecov configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,13 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: gradle dependencies
+      - run: ./gradlew dependencies
 
       - save_cache:
           paths:
             - ~/.m2
           key: v1-dependencies-{{ checksum "build.gradle" }}
 
-      - run: gradle test
+      - run: ./gradlew test
+
+      - run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Domain-Driven Design API for Kotlin [![CircleCI](https://circleci.com/gh/nemit/paju-ddd.svg?style=shield)](https://circleci.com/gh/nemit/paju-ddd)
+# Domain-Driven Design API for Kotlin [![CircleCI](https://circleci.com/gh/nemit/paju-ddd.svg?style=shield)](https://circleci.com/gh/nemit/paju-ddd) [![codecov](https://codecov.io/gh/nemit/paju-ddd/branch/master/graph/badge.svg)](https://codecov.io/gh/nemit/paju-ddd)
 
 This project explores Domain-Driven Design pattern with Kotlin. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,15 @@ buildscript {
 
 apply from: "gradle/ktlint.gradle"
 apply plugin: "org.jlleitschuh.gradle.ktlint"
+apply from: "$rootDir/gradle/jacocoreport.gradle"
+
+afterEvaluate {
+    def junitPlatformTestTask = tasks.getByName('junitPlatformTest')
+
+    jacoco {
+        applyTo junitPlatformTestTask
+    }
+}
 
 ktlint {
     verbose = true
@@ -28,37 +37,36 @@ allprojects {
     group 'nemit.fi'
     version '1.0-SNAPSHOT'
 
-//    apply plugin: 'org.junit.platform.gradle.plugin'
-//    apply from: "$rootDir/gradle/integrationtests.gradle"
-//
-//    junitPlatform {
-//        filters {
-//            tags {
-//                if(gradle.startParameter.taskRequests.flatten().find({ it.args.find {it == "integrationTests"}}) != null) {
-//                    exclude '*'
-//                    include 'integration'
-//                } else {
-//                    exclude 'integration'
-//                }
-//            }
-//        }
-//    }
-//
-//    repositories {
-//        mavenCentral()
-//    }
-//
-//    dependencies {
-//        testRuntime libs.junitJupiterEngine
-//    }
+    apply plugin: 'org.junit.platform.gradle.plugin'
+    apply from: "$rootDir/gradle/integrationtests.gradle"
+    apply plugin: "jacoco"
+
+    dependencies {
+        testRuntime libs.junitJupiterEngine
+    }
+
+    repositories {
+        maven {url "https://jcenter.bintray.com"}
+    }
+
+    junitPlatform { task ->
+        filters {
+            tags {
+                if(gradle.startParameter.taskRequests.flatten().find({ it.args.find {it == "integrationTests"}}) != null) {
+                    exclude '*'
+                    include 'integration'
+                } else {
+                    exclude 'integration'
+                }
+            }
+        }
+    }
+
 }
 
 subprojects {
 
     apply plugin: 'kotlin'
-    apply plugin: 'jacoco'
-    apply from: "$rootDir/gradle/jacocoreport.gradle"
-
     task allDeps(type: DependencyReportTask) {}
 
     repositories {
@@ -95,4 +103,3 @@ subprojects {
             }
     }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -28,35 +28,36 @@ allprojects {
     group 'nemit.fi'
     version '1.0-SNAPSHOT'
 
-    apply plugin: 'org.junit.platform.gradle.plugin'
-    apply from: "$rootDir/gradle/integrationtests.gradle"
-
-    junitPlatform {
-        filters {
-            tags {
-                if(gradle.startParameter.taskRequests.flatten().find({ it.args.find {it == "integrationTests"}}) != null) {
-                    exclude '*'
-                    include 'integration'
-                } else {
-                    exclude 'integration'
-                }
-            }
-        }
-    }
-
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        testRuntime libs.junitJupiterEngine
-    }
+//    apply plugin: 'org.junit.platform.gradle.plugin'
+//    apply from: "$rootDir/gradle/integrationtests.gradle"
+//
+//    junitPlatform {
+//        filters {
+//            tags {
+//                if(gradle.startParameter.taskRequests.flatten().find({ it.args.find {it == "integrationTests"}}) != null) {
+//                    exclude '*'
+//                    include 'integration'
+//                } else {
+//                    exclude 'integration'
+//                }
+//            }
+//        }
+//    }
+//
+//    repositories {
+//        mavenCentral()
+//    }
+//
+//    dependencies {
+//        testRuntime libs.junitJupiterEngine
+//    }
 }
 
 subprojects {
 
     apply plugin: 'kotlin'
-
+    apply plugin: 'jacoco'
+    apply from: "$rootDir/gradle/jacocoreport.gradle"
 
     task allDeps(type: DependencyReportTask) {}
 

--- a/gradle/jacocoreport.gradle
+++ b/gradle/jacocoreport.gradle
@@ -1,0 +1,18 @@
+task codeCoverageReport(type: JacocoReport) {
+    executionData fileTree(project.rootDir.absolutePath).include("**/build/jacoco/*.exec")
+
+    subprojects.each {
+        sourceSets it.sourceSets.main
+    }
+
+    reports {
+        xml.enabled true
+        xml.destination new File("${buildDir}/reports/jacoco/report.xml")
+        html.enabled false
+        csv.enabled false
+    }
+}
+
+codeCoverageReport.dependsOn {
+    subprojects*.test
+}

--- a/gradle/jacocoreport.gradle
+++ b/gradle/jacocoreport.gradle
@@ -12,7 +12,3 @@ task codeCoverageReport(type: JacocoReport) {
         csv.enabled false
     }
 }
-
-codeCoverageReport.dependsOn {
-    subprojects*.test
-}


### PR DESCRIPTION
Lisätään codecov statistiikat.

Projektin codecov osoite:
https://codecov.io/gh/nemit/paju-ddd

Kokeilin eri vaihtoehtoja, mutta jostain syytä anaylysointi ei onnitu jacoco-plugarilla. Luultavasti ongelma on junit5:ssa.

Tarkoitus ei ole ottaa pois junitPlatform taskia / configuraatiota. Olen vain testannut onko sillä vaikutusta. Sen pois kommentointi ei auta.

Linkkejä:
https://github.com/codecov/example-gradle
https://stackoverflow.com/questions/39362955/gradle-jacoco-and-junit5


**Status:** kesken, ei toimi

Closes #18