### PR TITLE
Add Bintray publish scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,11 @@ Make Intellij IDEA's built-in formatter produce 100% ktlint-compatible code with
 ```bash
 $ ./gradlew ktlintToIdea
 ```
+
+### Publish project artifact to Bintray
+
+```bash
+export BINTRAY_USER=[user]; export BINTRAY_API_KEY=[apikey]; ./gradlew bintrayUpload  
+```
+
+Artifacts are published to <https://dl.bintray.com/nemit/oss-libs/paju-ddd/>

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath pluginLibs.ktlintPlugin
         ktlint pluginLibs.ktlint
         classpath pluginLibs.junitGradlePlugin
+        classpath pluginLibs.bintrayPlugin
     }
 }
 
@@ -25,11 +26,11 @@ ktlint {
 }
 
 allprojects {
-    group 'nemit.fi'
-    version '1.0-SNAPSHOT'
+    group 'paju-ddd'
+    version '1.0'
 
     apply plugin: 'org.junit.platform.gradle.plugin'
-    apply from: "$rootDir/gradle/integrationtests.gradle"
+    apply from: rootProject.file('gradle/integrationtests.gradle')
 
     junitPlatform {
         filters {
@@ -56,7 +57,6 @@ allprojects {
 subprojects {
 
     apply plugin: 'kotlin'
-
 
     task allDeps(type: DependencyReportTask) {}
 

--- a/ddd-core/build.gradle
+++ b/ddd-core/build.gradle
@@ -1,0 +1,1 @@
+apply from: rootProject.file('gradle/bintray.gradle')

--- a/gradle/bintray.gradle
+++ b/gradle/bintray.gradle
@@ -1,0 +1,54 @@
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
+apply plugin: 'java'
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            mavenJava(MavenPublication) {
+                artifactId = archivesBaseName
+
+                pom.withXml {
+                    asNode().appendNode('name', archivesBaseName)
+                    asNode().appendNode('description', description)
+                    asNode().appendNode('url', 'https://github.com/nemit/paju-ddd.git')
+                    asNode().appendNode('licenses').appendNode('license').
+                            appendNode('name', 'Apache License, Version 2.0').parent().
+                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.html')
+                }
+                from components.java
+
+                artifact sourcesJar
+            }
+        }
+    }
+}
+
+bintray {
+    user = System.getenv('BINTRAY_USER')
+    key = System.getenv('BINTRAY_API_KEY')
+
+    dryRun = false
+    publish = true
+    publications = ['mavenJava']
+    pkg {
+        repo = 'oss-libs'
+        name = 'paju-ddd'
+        userOrg = 'nemit'
+        licenses = ['Apache-2.0']
+        vcsUrl = 'https://github.com/nemit/paju-ddd.git'
+        labels = []
+        publicDownloadNumbers = true
+        version {
+            name = project.version
+            desc = project.description
+            released  = new Date()
+        }
+    }
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,8 @@ ext {
             // plugins
             dependencyManagementPlugin : '1.0.3.RELEASE',
             ktlint                  : '0.11.0',
-            ktlintPlugin            : '2.2.1'
+            ktlintPlugin            : '2.2.1',
+            bintrayPlugin           : '1.7.3'
     ]
 
     libs = [
@@ -58,6 +59,7 @@ ext {
             ktlint                  : "com.github.shyiko:ktlint:$versions.ktlint",
             springBootGradlePlugin  : "org.springframework.boot:spring-boot-gradle-plugin:$versions.springBoot",
             kotlinAllOpen           : "org.jetbrains.kotlin:kotlin-allopen:$versions.kotlin",
-            junitGradlePlugin       : "org.junit.platform:junit-platform-gradle-plugin:$versions.junitGradlePlugin"
+            junitGradlePlugin       : "org.junit.platform:junit-platform-gradle-plugin:$versions.junitGradlePlugin",
+            bintrayPlugin           : "com.jfrog.bintray.gradle:gradle-bintray-plugin:$versions.bintrayPlugin"
     ]
 }


### PR DESCRIPTION
Scripts that publish maven artifact(s) to Bintray. 

Artifacts are available for everyone: <https://dl.bintray.com/nemit/oss-libs/paju-ddd/>

How to get **write** permissions to Bintray `oss-libs`-repo?

1. Create Bintray account
2. Send username to me
3. I will grant write permissions to repository