### PR TITLE
initialState function refactored to abstract var

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ ktlint {
 
 allprojects {
     group 'paju-ddd'
-    version '1.0.1'
+    version '1.1.0'
 
     apply plugin: 'org.junit.platform.gradle.plugin'
     apply from: rootProject.file('gradle/integrationtests.gradle')

--- a/ddd-core/src/main/kotlin/io/paju/ddd/AggregateRoot.kt
+++ b/ddd-core/src/main/kotlin/io/paju/ddd/AggregateRoot.kt
@@ -1,26 +1,17 @@
 package io.paju.ddd
 
-abstract class AggregateRoot<S: State, E : StateChangeEvent>
+abstract class AggregateRoot<S: State, E : StateChangeEvent>(val id: AggregateRootId)
 {
-    val id: AggregateRootId
     var version: Int = 0
-    private var state: S
-    private val changes: MutableList<E> // all new uncommitted events
-    protected val eventMediator: EventMediator
-
-    constructor(id: AggregateRootId) {
-        this.id = id
-        this.state = initialState()
-        this.changes = mutableListOf<E>()
-        this.eventMediator = EventMediator()
-    }
+    abstract protected var aggregateState: S
+    private val changes: MutableList<E> = mutableListOf()// all new uncommitted events
+    protected val eventMediator: EventMediator = EventMediator()
 
     protected abstract fun instanceCreated(): E // the first event in event stream / list
-    protected abstract fun initialState(): S
     protected abstract fun apply(event: E, toState: S): S
 
     // get aggregate state
-    protected fun getState(): S = state
+    protected fun getState(): S = aggregateState
 
     // aggregate state modification events
     protected fun applyChange(event: E) {
@@ -28,7 +19,7 @@ abstract class AggregateRoot<S: State, E : StateChangeEvent>
     }
 
     private fun applyChange(event: E, isNew: Boolean) {
-        state = apply(event, state)
+        aggregateState = apply(event, aggregateState)
         if (isNew) {
             changes.add(event)
         }
@@ -64,7 +55,7 @@ abstract class AggregateRoot<S: State, E : StateChangeEvent>
 
         fun fromState(state: S): A =
             aggregate.apply {
-                this.state = state
+                this.aggregateState = state
             }
     }
 }

--- a/ddd-core/src/test/kotlin/io/paju/ddd/CounterAggregate.kt
+++ b/ddd-core/src/test/kotlin/io/paju/ddd/CounterAggregate.kt
@@ -6,6 +6,8 @@ class CounterAggregate(id: AggregateRootId) :
     AggregateRoot<CounterState, CounterEvent>(id),
     StateExposed<CounterState>
 {
+    override var aggregateState = CounterState()
+
     // public api
     fun add() {
         applyChange(CounterEvent.Added)
@@ -17,15 +19,13 @@ class CounterAggregate(id: AggregateRootId) :
 
     override fun state(): CounterState = getState()
 
-    override fun initialState(): CounterState = CounterState()
-
     override fun instanceCreated(): CounterEvent = CounterEvent.InstanceCreated
 
     internal fun getEventMediator() = eventMediator
 
     override fun apply(event: CounterEvent, toState: CounterState): CounterState {
         return when (event) {
-            is CounterEvent.InstanceCreated -> initialState()
+            is CounterEvent.InstanceCreated -> aggregateState
             is CounterEvent.Added -> toState.copy( counter = toState.counter + 1 )
             is CounterEvent.Subtracted -> toState.copy( counter = toState.counter - 1 )
         }

--- a/examples/sales-order/domain/src/main/kotlin/io/paju/salesorder/domain/SalesOrder.kt
+++ b/examples/sales-order/domain/src/main/kotlin/io/paju/salesorder/domain/SalesOrder.kt
@@ -19,19 +19,17 @@ class SalesOrder constructor(id: AggregateRootId) :
     StateExposed<SalesOrderState>
 {
     private val stateManager = SalesOrderStateManager({ getState() })
-
-    internal fun getEventMediator() = eventMediator
-
-    override fun initialState() = SalesOrderState(
+    override var aggregateState =  SalesOrderState(
         1, null, false, false, mutableListOf()
     )
 
+    internal fun getEventMediator() = eventMediator
     override fun state(): SalesOrderState = getState()
     override fun instanceCreated(): SalesOrderEvent = SalesOrderEvent.Created
 
     override fun apply(event: SalesOrderEvent, toState: SalesOrderState): SalesOrderState {
         return when (event) {
-            is SalesOrderEvent.Created -> initialState()
+            is SalesOrderEvent.Created -> aggregateState
             is SalesOrderEvent.CustomerSet -> stateManager.apply(event)
             is SalesOrderEvent.Deleted -> stateManager.apply(event)
             is SalesOrderEvent.Confirmed -> stateManager.apply(event)


### PR DESCRIPTION
initialState function was called in AggregateRoot constructor which is
unsafe for implementations that require own constructor properties which
are used in creation of the initial state.

Property named "aggregateState" as state was jvm signature conflict with getState()
  